### PR TITLE
Distribute as Python package over PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,20 @@ For further information see:
 
 ## Installation
 
-The python script `repoload.py` is self contained.  Just drop the file
-in a folder that your environment variable `PATH` references.
+The installation of `repoload` is possible over PyPI or by directly using the
+python script.
+
+PyPI:
+
+    $ python3 -m pip install --user repoload
+
+To manually install the self contained `repoload.py` python script. Just drop
+the file in a folder that your environment variable `PATH` references.
 
 Example:
 
     $ mkdir -p ~/bin
-    $ cp repoload.py ~/bin/repoload
+    $ cp repoload/repoload.py ~/bin/repoload
     $ echo 'export PATH=$PATH:$HOME/bin' >> ~/.bashrc
     $ chmod +x ~/bin/repoload  # ensure that the script is executeable
 
@@ -95,6 +102,23 @@ After that the command
     $ repoload changes
 
 should print a list of open change requests.
+
+
+## Create and publish a release
+
+To create a release of repoload additional packaging dependency's are needed:
+
+    $ python3 -m pip install --user --upgrade twine setuptools wheel
+
+Next the release which is described in the setup.py file gets packaged.
+The version number is taken from the repoload/repoload.py `__VERSION__` string.
+
+    $ python3 setup.py sdist bdist_wheel
+
+As final step the release can be uploaded to PyPI.
+See the PyPI documentation on how to configure the credentials for twine.
+
+    $ python3 -m twine upload dist/*
 
 
 ## License

--- a/repoload/__main__.py
+++ b/repoload/__main__.py
@@ -1,0 +1,9 @@
+#
+# Copyright 2019 David Zerulla
+#
+# SPDX-License-Identifier: MIT
+
+"""Executed when `python3 -m repoload` is used."""
+
+from .repoload import main
+main()

--- a/repoload/repoload.py
+++ b/repoload/repoload.py
@@ -14,7 +14,7 @@ import sys
 import json
 import os
 
-__VERSION__ = "0.1"
+__VERSION__ = "0.1.1"
 
 # TODO Get this url from the manifest repo at the path '.repo/manifests.git/'.
 # This will mostly be the correct gerrit server url. Overwriting by a

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,40 @@
+#
+# Copyright 2019 David Zerulla
+#
+# SPDX-License-Identifier: MIT
+
+"""Repoload - a change request download tool."""
+
+import re
+import setuptools
+
+version = re.search('^__VERSION__\s*=\s*"(.*)"',
+                    open('repoload/repoload.py').read(),
+                    re.M
+                    ).group(1)
+
+long_description = open('README.md').read()
+
+setuptools.setup(
+    name="repoload",
+    version=version,
+    author="Stefan Lengfeld, David Zerulla",
+    author_email="contact@stefanchrist.eu, ddaze@outlook.de",
+    license="MIT",
+    description=__doc__,
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    keywords="repoload repo gerrit",
+    url="https://github.com/lengfeld/repoload",
+    packages=["repoload"],
+    entry_points = {
+        "console_scripts": ['repoload = repoload.repoload:main']
+    },
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    python_requires='>=3.5',
+    platforms='any',
+)


### PR DESCRIPTION
Allow the repoload tool to be published to PyPI.

```
  # Install the package and upload tools
  python3 -m pip install --user --upgrade twine setuptools wheel

  # Package repolint
  python3 setup.py sdist bdist_wheel

  # Upload the package to PyPI
  python3 -m twine upload dist/*
```